### PR TITLE
Replaced most std::cout with fwrite()

### DIFF
--- a/ConsoleCraftEngine.vcxproj
+++ b/ConsoleCraftEngine.vcxproj
@@ -94,6 +94,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>GE_BUILD_DLL; WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -108,6 +109,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>GE_BUILD_DLL; WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -122,6 +124,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>GE_BUILD_DLL; _DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -136,6 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>GE_BUILD_DLL; NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/CraftMatch/CraftMatch.vcxproj
+++ b/CraftMatch/CraftMatch.vcxproj
@@ -126,6 +126,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Source/Core/Renderer.cpp
+++ b/Source/Core/Renderer.cpp
@@ -145,7 +145,7 @@ void Renderer::ClearObjectTrailAfterCameraMove(GameObject &go, Scene &scene)
                 }
 
                 GoToXY(clearX, clearY);
-                print("");
+                print(" ");
             }
         }
     }

--- a/Source/Core/Renderer.cpp
+++ b/Source/Core/Renderer.cpp
@@ -34,6 +34,12 @@ void Renderer::Render(Scene &scene)
     scene.camera->HasMovedDirection = 0;
 }
 
+void Renderer::print(std::string_view str)
+{
+    // fwrite: fastest way to print to the console
+    fwrite(str.data(), str.size(), 1, stdout);
+}
+
 void Renderer::ClearDestroyedObject(GameObject &go, Scene &scene)
 {
     for (int i = 0; i < go.GetHeight() + 2; i++)
@@ -44,7 +50,7 @@ void Renderer::ClearDestroyedObject(GameObject &go, Scene &scene)
             int posY = static_cast<int>(go.transform.Position.Y + i - 1) + scene.camera->offsetY;
 
             GoToXY(posX, posY);
-            std::cout << ' ';
+            print(" ");
         }
     }
     go.hasClearedFromScreen = true;
@@ -71,7 +77,7 @@ void Renderer::DrawObjects(GameObject &go, Scene &scene)
                 SetConsoleColor(color);
             }
             GoToXY(posX, posY);
-            std::cout << go.symbol;
+            print(go.symbol);
         }
     }
     SetConsoleColor(15);
@@ -94,7 +100,7 @@ void Renderer::ClearMovedObjectsTrail(GameObject &go, Scene &scene)
                 }
 
                 GoToXY(clearX, clearY);
-                std::cout << ' ';
+                print(" ");
             }
         }
 
@@ -139,7 +145,7 @@ void Renderer::ClearObjectTrailAfterCameraMove(GameObject &go, Scene &scene)
                 }
 
                 GoToXY(clearX, clearY);
-                std::cout << ' ';
+                print("");
             }
         }
     }
@@ -151,7 +157,7 @@ void Renderer::DrawUI(const Scene &scene)
     {
         GoToXY(uiData->position.X, uiData->position.Y);
         std::string s(uiData->text.size() + 1, ' ');
-        std::cout << s;
+        print(s);
     }
     for (auto &panel : scene.uiHandler->uiPanels)
     {
@@ -162,7 +168,7 @@ void Renderer::DrawUI(const Scene &scene)
                 if (uiData->isActive)
                 {
                     GoToXY(uiData->position.X, uiData->position.Y);
-                    std::cout << uiData->text;
+                    print(uiData->text);
                 }
             }
         }
@@ -174,7 +180,7 @@ void Renderer::DrawUI(const Scene &scene)
 
                 GoToXY(uiData->position.X, uiData->position.Y);
                 std::string s(uiData->text.size() + 40, ' ');
-                std::cout << s;
+                print(s);
             }
         }
     }
@@ -183,7 +189,7 @@ void Renderer::DrawUI(const Scene &scene)
         if (uiData->isActive)
         {
             GoToXY(uiData->position.X, uiData->position.Y);
-            std::cout << uiData->text;
+            print(uiData->text);
         }
     }
 }

--- a/Source/Core/Renderer.h
+++ b/Source/Core/Renderer.h
@@ -6,6 +6,8 @@
 #else
 #include <Windows.h>
 #endif
+#include <string_view>
+
 class GE_API Renderer
 {
 public:
@@ -48,6 +50,7 @@ private:
 #endif
     }
 
+    void print(std::string_view str);
     void ClearDestroyedObject(GameObject &go, Scene &scene);
     void DrawObjects(GameObject &go, Scene &scene);
     void ClearMovedObjectsTrail(GameObject &go, Scene &scene);


### PR DESCRIPTION
Hi I just saw Chernos video your project, and was immediately drawn to it. I have some experience building console rendered games and applications, and thought i could contribute a bit with the knowledge i have gathered in my projects.
I don't know if you want anyone to contribute, but here i am, and here is what i did:

Replaced most std::cout with fwrite() in Renderer.cpp.
frwite() is the fastest way to print to console and allows for a high frame rate even with loads of text to print.
I also updated the C++ version from C++14 to C++17 to be able to use std::string_view, If you don't want to upgrade you can just replace the std::string_view with const std::string&.
